### PR TITLE
Number input to contain comma as a decimal point

### DIFF
--- a/source/community/reactnative/src/components/inputs/number-input.js
+++ b/source/community/reactnative/src/components/inputs/number-input.js
@@ -10,7 +10,7 @@ import { HostConfigManager } from '../../utils/host-config';
 import { Input } from './input';
 import * as Enums from '../../utils/enums';
 
-const NUM_REGEX = /^\-?[0-9]\d*(\.\d*)?$/;
+const NUM_REGEX = /^\-?[0-9]\d*([\.\,]\d*)?$/;
 
 export class NumberInput extends React.Component {
 


### PR DESCRIPTION
Some locales use "," instead of "." for decimal numbers. Ex:- Swedish Locale. So I have edited the regex allowing ","
